### PR TITLE
Simplify a bunch of types by making things less generic.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,13 +92,12 @@ pub fn eval<I: io::Read, O: io::Write>(
     input: &mut I,
     output: &mut O,
 ) -> Result<(), RenderCommandError> {
-    let shared_content_engine =
-        FilesystemBasedContentEngine::<ServerInfo, ()>::from_content_directory(
-            content_directory,
-            ServerInfo {
-                version: operator_version,
-            },
-        )?;
+    let shared_content_engine = FilesystemBasedContentEngine::from_content_directory(
+        content_directory,
+        ServerInfo {
+            version: operator_version,
+        },
+    )?;
     let content_engine = shared_content_engine
         .read()
         .expect("RwLock for ContentEngine has been poisoned");
@@ -134,13 +133,12 @@ pub fn get<O: io::Write>(
     operator_version: ServerVersion,
     output: &mut O,
 ) -> Result<(), GetCommandError> {
-    let shared_content_engine =
-        FilesystemBasedContentEngine::<ServerInfo, ()>::from_content_directory(
-            content_directory,
-            ServerInfo {
-                version: operator_version,
-            },
-        )?;
+    let shared_content_engine = FilesystemBasedContentEngine::from_content_directory(
+        content_directory,
+        ServerInfo {
+            version: operator_version,
+        },
+    )?;
     let content_engine = shared_content_engine
         .read()
         .expect("RwLock for ContentEngine has been poisoned");

--- a/src/content/content_item.rs
+++ b/src/content/content_item.rs
@@ -78,14 +78,13 @@ impl RegisteredTemplate {
         }
     }
 
-    pub(super) fn render_to_native_media_type<ServerInfo, ErrorCode>(
+    pub(super) fn render_to_native_media_type<ServerInfo>(
         &self,
         handlebars_registry: &Handlebars,
-        render_data: RenderData<ServerInfo, ErrorCode>,
+        render_data: RenderData<ServerInfo>,
     ) -> Result<Media<InMemoryBody>, RenderingFailedError>
     where
         ServerInfo: Clone + Serialize,
-        ErrorCode: Clone + Serialize,
     {
         let render_data = RenderData {
             target_media_type: Some(self.rendered_media_type.clone()),
@@ -116,14 +115,13 @@ impl UnregisteredTemplate {
         })
     }
 
-    pub(super) fn render_to_native_media_type<ServerInfo, ErrorCode>(
+    pub(super) fn render_to_native_media_type<ServerInfo>(
         &self,
         handlebars_registry: &Handlebars,
-        render_data: RenderData<ServerInfo, ErrorCode>,
+        render_data: RenderData<ServerInfo>,
     ) -> Result<Media<InMemoryBody>, RenderingFailedError>
     where
         ServerInfo: Clone + Serialize,
-        ErrorCode: Clone + Serialize,
     {
         let render_data = RenderData {
             target_media_type: Some(self.rendered_media_type.clone()),
@@ -144,15 +142,14 @@ impl UnregisteredTemplate {
 }
 impl Render for UnregisteredTemplate {
     type Output = InMemoryBody;
-    fn render<'accept, ServerInfo, ErrorCode, Engine, Accept>(
+    fn render<'accept, ServerInfo, Engine, Accept>(
         &self,
-        context: RenderContext<ServerInfo, ErrorCode, Engine>,
+        context: RenderContext<ServerInfo, Engine>,
         acceptable_media_ranges: Accept,
     ) -> Result<Media<Self::Output>, RenderError>
     where
         ServerInfo: Clone + Serialize,
-        ErrorCode: Clone + Serialize,
-        Engine: ContentEngine<ServerInfo, ErrorCode>,
+        Engine: ContentEngine<ServerInfo>,
         Accept: IntoIterator<Item = &'accept MediaRange>,
         Self::Output: ByteStream,
     {

--- a/src/content/content_registry.rs
+++ b/src/content/content_registry.rs
@@ -29,15 +29,14 @@ pub enum RegisteredContent {
 
 impl Render for ContentRepresentations {
     type Output = Box<dyn ByteStream>;
-    fn render<'accept, ServerInfo, ErrorCode, Engine, Accept>(
+    fn render<'accept, ServerInfo, Engine, Accept>(
         &self,
-        context: RenderContext<ServerInfo, ErrorCode, Engine>,
+        context: RenderContext<ServerInfo, Engine>,
         acceptable_media_ranges: Accept,
     ) -> Result<Media<Self::Output>, RenderError>
     where
-        ErrorCode: Clone + Serialize,
         ServerInfo: Clone + Serialize,
-        Engine: ContentEngine<ServerInfo, ErrorCode>,
+        Engine: ContentEngine<ServerInfo>,
         Accept: IntoIterator<Item = &'accept MediaRange>,
         Self::Output: ByteStream,
     {
@@ -117,7 +116,7 @@ mod tests {
 
     /// All of these will render to an empty string with media type text/plain
     /// or text/html.
-    fn fixtures() -> (impl ContentEngine<(), ()>, Vec<ContentRepresentations>) {
+    fn fixtures() -> (impl ContentEngine<()>, Vec<ContentRepresentations>) {
         let text_plain = MediaType::from_media_range(::mime::TEXT_PLAIN).unwrap();
         let text_html = MediaType::from_media_range(::mime::TEXT_HTML).unwrap();
         let mut content_engine = MockContentEngine::new();

--- a/src/content/handlebars_helpers/get.rs
+++ b/src/content/handlebars_helpers/get.rs
@@ -5,37 +5,31 @@ use handlebars::{self, Handlebars};
 use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 
-pub struct GetHelper<ServerInfo, ErrorCode, Engine>
+pub struct GetHelper<ServerInfo, Engine>
 where
     ServerInfo: Clone + Serialize,
-    ErrorCode: Clone + Serialize,
-    Engine: ContentEngine<ServerInfo, ErrorCode>,
+    Engine: ContentEngine<ServerInfo>,
 {
     content_engine: Arc<RwLock<Engine>>,
     server_info_type: PhantomData<ServerInfo>,
-    error_code_type: PhantomData<ErrorCode>,
 }
-impl<ServerInfo, ErrorCode, Engine> GetHelper<ServerInfo, ErrorCode, Engine>
+impl<ServerInfo, Engine> GetHelper<ServerInfo, Engine>
 where
     ServerInfo: Clone + Serialize,
-    ErrorCode: Clone + Serialize,
-    Engine: ContentEngine<ServerInfo, ErrorCode>,
+    Engine: ContentEngine<ServerInfo>,
 {
     pub fn new(content_engine: Arc<RwLock<Engine>>) -> Self {
         Self {
             content_engine,
             server_info_type: PhantomData,
-            error_code_type: PhantomData,
         }
     }
 }
 
-impl<ServerInfo, ErrorCode, Engine> handlebars::HelperDef
-    for GetHelper<ServerInfo, ErrorCode, Engine>
+impl<ServerInfo, Engine> handlebars::HelperDef for GetHelper<ServerInfo, Engine>
 where
     ServerInfo: Clone + Serialize,
-    ErrorCode: Clone + Serialize,
-    Engine: ContentEngine<ServerInfo, ErrorCode>,
+    Engine: ContentEngine<ServerInfo>,
 {
     fn call<'registry: 'context, 'context>(
         &self,

--- a/src/content/test_lib.rs
+++ b/src/content/test_lib.rs
@@ -20,8 +20,8 @@ impl<'a> MockContentEngine<'a> {
             .register_template_string(template_name, template_contents)
     }
 }
-impl<'a> ContentEngine<(), ()> for MockContentEngine<'a> {
-    fn get_render_context(&self, request_route: &str) -> RenderContext<(), (), Self> {
+impl<'a> ContentEngine<()> for MockContentEngine<'a> {
+    fn get_render_context(&self, request_route: &str) -> RenderContext<(), Self> {
         RenderContext {
             content_engine: self,
             data: RenderData {

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,11 +11,9 @@ use std::marker::PhantomData;
 use std::net::ToSocketAddrs;
 use std::sync::{Arc, RwLock};
 
-type HttpStatusCodeNumber = u16;
-
 struct AppData<
     ServerInfo: Clone + Serialize,
-    Engine: 'static + ContentEngine<ServerInfo, HttpStatusCodeNumber> + Send + Sync,
+    Engine: 'static + ContentEngine<ServerInfo> + Send + Sync,
 > {
     shared_content_engine: Arc<RwLock<Engine>>,
     index_route: Option<String>,
@@ -32,7 +30,7 @@ pub fn run_server<ServerInfo, SocketAddress, Engine>(
 where
     ServerInfo: 'static + Clone + Serialize,
     SocketAddress: 'static + ToSocketAddrs,
-    Engine: 'static + ContentEngine<ServerInfo, HttpStatusCodeNumber> + Send + Sync,
+    Engine: 'static + ContentEngine<ServerInfo> + Send + Sync,
 {
     log::info!("Initializing HTTP server");
     let mut system = System::new("server");
@@ -75,7 +73,7 @@ where
 async fn get<ServerInfo, Engine>(request: HttpRequest) -> HttpResponse
 where
     ServerInfo: 'static + Clone + Serialize,
-    Engine: 'static + ContentEngine<ServerInfo, HttpStatusCodeNumber> + Send + Sync,
+    Engine: 'static + ContentEngine<ServerInfo> + Send + Sync,
 {
     let app_data = request
         .app_data::<AppData<ServerInfo, Engine>>()
@@ -247,7 +245,7 @@ fn error_response<ServerInfo, Engine>(
 ) -> HttpResponse
 where
     ServerInfo: 'static + Clone + Serialize,
-    Engine: 'static + ContentEngine<ServerInfo, HttpStatusCodeNumber> + Send + Sync,
+    Engine: 'static + ContentEngine<ServerInfo> + Send + Sync,
 {
     let error_code = if !status_code.is_client_error() && !status_code.is_server_error() {
         log::error!(
@@ -350,7 +348,7 @@ mod tests {
     use bytes::{Bytes, BytesMut};
     use std::path::Path;
 
-    type TestContentEngine<'a> = FilesystemBasedContentEngine<'a, (), HttpStatusCodeNumber>;
+    type TestContentEngine<'a> = FilesystemBasedContentEngine<'a, ()>;
 
     fn test_request(
         content_directory_path: &Path,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -369,14 +369,14 @@ fn is_omitted_from_snapshots(route: &str) -> bool {
 fn use_into_error_context() {
     use content::{ContentEngine, FilesystemBasedContentEngine};
     use std::path::Path;
-    let shared_engine = FilesystemBasedContentEngine::<(), ()>::from_content_directory(
+    let shared_engine = FilesystemBasedContentEngine::<()>::from_content_directory(
         ContentDirectory::from_root(&Path::new("/dev/null")).unwrap(),
         (),
     )
     .unwrap();
     let engine = shared_engine.read().unwrap();
     let context = engine.get_render_context("");
-    context.into_error_context(());
+    context.into_error_context(0);
 }
 
 // The rest of this file is the actual tests.


### PR DESCRIPTION
- `RenderData` lost its `ErrorCode` type parameter (which means so did `RenderContext`, `ContentEngine`, `Render::render`, etc). It's now always `u16`.
- `AppData` and other stuff in http.rs is no longer generic over the server info type. Now it's specific to the `lib::ServerInfo` struct.