### PR TITLE
Expose ContentFile struct fields to reduce clones.

### DIFF
--- a/src/content/content_directory.rs
+++ b/src/content/content_directory.rs
@@ -91,12 +91,12 @@ impl ContentDirectory {
 }
 
 pub struct ContentFile {
-    absolute_path: String,
-    relative_path: String,
-    is_executable: bool,
-    route: Route,
-    extensions: Vec<String>,
-    file: File,
+    pub absolute_path: String,
+    pub relative_path: String,
+    pub is_executable: bool,
+    pub route: Route,
+    pub extensions: Vec<String>,
+    pub file: File,
 }
 impl ContentFile {
     pub const PATH_SEPARATOR: char = '/';
@@ -221,34 +221,6 @@ impl ContentFile {
             file,
             is_executable,
         })
-    }
-
-    pub fn absolute_path(&self) -> &str {
-        &self.absolute_path
-    }
-
-    pub fn relative_path(&self) -> &str {
-        &self.relative_path
-    }
-
-    pub fn is_executable(&self) -> bool {
-        self.is_executable
-    }
-
-    pub fn route(&self) -> &Route {
-        &self.route
-    }
-
-    pub fn extensions(&self) -> &[String] {
-        &self.extensions
-    }
-
-    pub fn file(&self) -> &File {
-        &self.file
-    }
-
-    pub fn into_file(self) -> File {
-        self.file
     }
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -148,10 +148,8 @@ async fn render_everything_for_snapshots(
     let render_operations = content_directory
         .into_iter()
         .map(|content_file| async move {
-            let route = content_file.route();
             let empty_string = String::from("");
-            let first_filename_extension =
-                content_file.extensions().first().unwrap_or(&empty_string);
+            let first_filename_extension = content_file.extensions.first().unwrap_or(&empty_string);
 
             // Target media type is just the source media type.
             let target_media_type = MimeGuess::from_ext(first_filename_extension)
@@ -161,7 +159,7 @@ async fn render_everything_for_snapshots(
             let output = render_multiple_ways_for_snapshots(
                 optional_server.map(RunningServer::address),
                 content_directory,
-                route,
+                &content_file.route,
                 &target_media_type.to_string(),
             )
             .await;
@@ -178,10 +176,7 @@ async fn render_everything_for_snapshots(
                 }
             };
 
-            (
-                String::from(content_file.relative_path()),
-                output_or_error_message,
-            )
+            (content_file.relative_path.clone(), output_or_error_message)
         });
 
     let content = future::join_all(render_operations)


### PR DESCRIPTION
Struct fields can be borrowed independently (vs tying data to the lifetime of the struct like before). This helps get rid of some pesky `.clone()`s.