### PR TITLE
Remove an unnecessary seek.

### DIFF
--- a/src/content/content_directory.rs
+++ b/src/content/content_directory.rs
@@ -91,11 +91,17 @@ impl ContentDirectory {
 }
 
 pub struct ContentFile {
+    pub route: Route,
     pub absolute_path: String,
     pub relative_path: String,
-    pub is_executable: bool,
-    pub route: Route,
     pub extensions: Vec<String>,
+    pub is_executable: bool,
+
+    // All files are eagerly opened. The benefit is that content can be served
+    // quickly (at request time we can immediately start reading from the
+    // already-opened file), but the cost is that there can be many file
+    // descriptors open at once (so you might need to adjust ulimits to serve
+    // large content directories).
     pub file: File,
 }
 impl ContentFile {

--- a/src/content/content_item.rs
+++ b/src/content/content_item.rs
@@ -2,7 +2,7 @@ use super::*;
 use body::{FileBody, InMemoryBody, ProcessBody};
 use handlebars::{self, Handlebars, Renderable as _};
 use std::fs;
-use std::io::{self, Seek, SeekFrom};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use thiserror::Error;
@@ -55,11 +55,8 @@ impl StaticContentItem {
         &self,
     ) -> Result<Media<FileBody>, RenderingFailedError> {
         // We clone the file handle and operate on that to avoid taking
-        // self as mut. Note that all clones share a cursor, so seeking
-        // back to the beginning is necessary to ensure we read the
-        // entire file.
-        let mut file = self.contents.try_clone()?;
-        file.seek(SeekFrom::Start(0))?;
+        // self as mut.
+        let file = self.contents.try_clone()?;
         let stream = FileBody::try_from_file(file)?;
         Ok(Media::new(self.media_type.clone(), stream))
     }


### PR DESCRIPTION
The `Stream` impl for `FileBody` handles this now.