### PR TITLE
Switch from `exclude` to `include` in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,14 @@ repository = "https://github.com/mkantor/operator"
 readme = "README.md"
 license = "GPL-3.0"
 edition = "2018"
-exclude = [
-    "samples",
-    "tests",
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "README.md",
+
+    # Ideally this would not be necessary, but when `cargo publish` verifies
+    # the package tarball it checks [[bench]] and fails without this.
+    "benches/**/*",
 ]
 
 [dependencies]


### PR DESCRIPTION
This makes it easier to ensure the published package only contains what is necessary.