### PR TITLE
Remove a redundant category from package metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://operator.mattkantor.com"
 categories = [
     "web-programming::http-server",
     "command-line-utilities",
-    "network-programming",
 ]
 keywords = [
     "web",


### PR DESCRIPTION
After seeing [what it looks like on crates.io](https://crates.io/crates/operator), I've decided that since Operator has the "web-programming::http-server" category, also having "network-programming" is not useful and may even be confusing. Out of [the available options](https://crates.io/category_slugs) I think "web-programming::http-server" plus "command-line-utilities" is the maximally-informative set of categories for this package.