### PR TITLE
Temporarily revert to non-HTTPS Operator website URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ templates](samples/realistic-advanced/home.html.hbs) or
 [executables](samples/realistic-advanced/play-lottery.html.sh).
 
 More information is available on [the Operator
-website](https://operator.mattkantor.com).
+website](http://operator.mattkantor.com).
 
 ## Installation
 


### PR DESCRIPTION
I goofed and hit a Let's Encrypt rate limit, and it'll be a few days before I can request a new cert. Whoops!