### PR TITLE
Un-revert (re-revert?) to HTTPS URL for Operator website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ templates](samples/realistic-advanced/home.html.hbs) or
 [executables](samples/realistic-advanced/play-lottery.html.sh).
 
 More information is available on [the Operator
-website](http://operator.mattkantor.com).
+website](https://operator.mattkantor.com).
 
 ## Installation
 


### PR DESCRIPTION
Do not merge this until after the rate limit has expired and the live site has been redeployed.

See <https://github.com/mkantor/operator-website/pull/19> too.