### PR TITLE
Include CPU architecture in built artifact names.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,10 @@ jobs:
         - macos-latest
         include:
           - os: macos-latest
-            artifact_prefix: macos
+            artifact_prefix: macos-x86-64
             target: x86_64-apple-darwin
           - os: ubuntu-latest
-            artifact_prefix: linux
+            artifact_prefix: linux-x86-64
             target: x86_64-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Apple's new [M1 architecture](https://en.wikipedia.org/wiki/Apple_M1) made me realize I wasn't providing enough platform information for build artifacts. I really should have been doing this from the start (`operator-linux.tar.gz` isn't specific enough either).

[The Operator website](operator.mattkantor.com/) needs some updates too. First of all to refer to the new artifact names, but also the requisite architecture should be clearly called out in the install instructions.