### PR TITLE
Provide render data to executables via an environment variable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
 name = "async-trait"
@@ -588,7 +588,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.0",
+ "itertools 0.10.1",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -756,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1182,9 +1182,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "linked-hash-map"
@@ -1659,7 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
@@ -1676,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
@@ -1904,6 +1904,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -2105,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ include = [
 [dependencies]
 actix-rt = "1.1.1"
 actix-web = "3.3.2"
-anyhow = "1.0.40"
+anyhow = "1.0.41"
 bytes = "0.5.6"
 futures = "0.3.15"
 handlebars = "4.0.0"
@@ -40,6 +40,7 @@ log = "0.4.14"
 mime = "0.3.16"
 mime_guess = "2.0.3"
 serde = { version = "1.0.126", features = ["derive"] }
+serde_json = { version = "1.0.64", features = ["preserve_order"] }
 stderrlog = "0.5.1"
 structopt = "0.3.21"
 thiserror = "1.0.25"
@@ -47,12 +48,11 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 criterion = "0.3.4"
-env_logger = "0.8.3"
+env_logger = "0.8.4"
 insta = "1.7.1"
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 regex = "1.5.4"
-serde_json = "1.0.64"
 tempfile = "3.2.0"
 test-env-log = "0.2.7"
 

--- a/samples/executables/render-data.txt.sh
+++ b/samples/executables/render-data.txt.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$OPERATOR_RENDER_DATA"

--- a/src/content/content_index.rs
+++ b/src/content/content_index.rs
@@ -1,6 +1,6 @@
 use super::Route;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -43,10 +43,10 @@ pub enum ContentIndex {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct ContentIndexEntries(HashMap<String, ContentIndex>);
+pub struct ContentIndexEntries(BTreeMap<String, ContentIndex>);
 impl ContentIndexEntries {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(BTreeMap::new())
     }
 
     pub fn try_add(&mut self, route: Route) -> Result<(), ContentIndexUpdateError> {

--- a/src/content/content_registry.rs
+++ b/src/content/content_registry.rs
@@ -63,9 +63,9 @@ impl Render for ContentRepresentations {
                                 context.data.clone(),
                             )
                             .map(box_media),
-                        RegisteredContent::Executable(renderable) => {
-                            renderable.render_to_native_media_type().map(box_media)
-                        }
+                        RegisteredContent::Executable(renderable) => renderable
+                            .render_to_native_media_type(context.data.clone())
+                            .map(box_media),
                     };
 
                     // If rendering succeeded, return immediately. Otherwise

--- a/src/content/route.rs
+++ b/src/content/route.rs
@@ -25,7 +25,7 @@ fn canonicalize_route(route: &str) -> Result<String, InvalidRouteError> {
     }
 }
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Hash, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Route(String);
 impl FromStr for Route {
     type Err = InvalidRouteError;

--- a/tests/snapshots/integration_tests__executables.snap
+++ b/tests/snapshots/integration_tests__executables.snap
@@ -2,15 +2,18 @@
 source: tests/integration_tests.rs
 expression: contents
 input_file: samples/executables
+
 ---
 cat.txt.sh: ""
 count-cli-args.txt.sh: "0\n"
 error.txt.sh: "Unable to emit rendered content.\n\nCaused by:\n    Process exited with code 1: boom!\n    \n"
-ls.txt.sh: "NO-SNAPSHOT-random.bin.sh\nNO-SNAPSHOT-system-info.html.sh\ncat.txt.sh\ncount-cli-args.txt.sh\nerror.txt.sh\nls.txt.sh\noutput-and-error.txt.sh\npwd.txt.sh\nslow-error.txt.sh\nslow-template.txt.hbs\nslow.txt.sh\nsubdirectory\ntemplate.txt.hbs\n"
+ls.txt.sh: "NO-SNAPSHOT-random.bin.sh\nNO-SNAPSHOT-system-info.html.sh\ncat.txt.sh\ncount-cli-args.txt.sh\nerror.txt.sh\nls.txt.sh\noutput-and-error.txt.sh\npwd.txt.sh\nrender-data.txt.sh\nslow-error.txt.sh\nslow-template.txt.hbs\nslow.txt.sh\nsubdirectory\ntemplate.txt.hbs\n"
 output-and-error.txt.sh: "Unable to emit rendered content.\n\nCaused by:\n    Process exited with code 1\n"
 pwd.txt.sh: "$PROJECT_DIRECTORY/samples/executables\n"
+render-data.txt.sh: "{\"/\":{\"NO-SNAPSHOT-random\":\"/NO-SNAPSHOT-random\",\"NO-SNAPSHOT-system-info\":\"/NO-SNAPSHOT-system-info\",\"cat\":\"/cat\",\"count-cli-args\":\"/count-cli-args\",\"error\":\"/error\",\"ls\":\"/ls\",\"output-and-error\":\"/output-and-error\",\"pwd\":\"/pwd\",\"render-data\":\"/render-data\",\"slow\":\"/slow\",\"slow-error\":\"/slow-error\",\"slow-template\":\"/slow-template\",\"subdirectory/\":{\"pwd\":\"/subdirectory/pwd\"},\"template\":\"/template\"},\"server-info\":{\"version\":\"0.1.2\"},\"request-route\":\"/render-data\",\"target-media-type\":\"text/plain\",\"error-code\":null}\n"
 slow-error.txt.sh: "Unable to emit rendered content.\n\nCaused by:\n    Process exited with code 1: Boom!\n    \n"
 slow-template.txt.hbs: "﻿🔴 Ready…\n🟡 Set…\n🟢 Go!\n🏁 Finished!\n"
 slow.txt.sh: "﻿🔴 Ready…\n🟡 Set…\n🟢 Go!\n"
 subdirectory/pwd.txt.sh: "$PROJECT_DIRECTORY/samples/executables/subdirectory\n"
 template.txt.hbs: "this is pwd from subdirectory:\n$PROJECT_DIRECTORY/samples/executables/subdirectory\n"
+


### PR DESCRIPTION
Executables now have an `OPERATOR_RENDER_DATA` environment variable set, containing JSON-serialized [`RenderData`](https://github.com/mkantor/operator/blob/0.1.2/src/content/mod.rs#L114-L123). This is the same data that is provided to handlebars templates (including the content index, server info, request data, etc).

This is necessary but not sufficient for #12. For that, Operator would also need to track additional request info in `RenderData` (query parameters, request headers/body, etc). It may also be nice to set additional environment variables to follow [the CGI spec](https://datatracker.ietf.org/doc/html/rfc3875) (or something in the family) as per [this comment](https://github.com/mkantor/operator/issues/12#issuecomment-686832996), but this isn't strictly necessary.