### PR TITLE
Encapsulate internal resolution of hidden routes.

### DIFF
--- a/src/content/content_engine.rs
+++ b/src/content/content_engine.rs
@@ -61,11 +61,12 @@ where
         media_type: MediaType,
     ) -> Result<UnregisteredTemplate, TemplateError>;
 
-    fn get_internal(&self, route: &Route) -> Option<&ContentRepresentations>;
-
     fn get(&self, route: &Route) -> Option<&ContentRepresentations>;
 
     fn handlebars_registry(&self) -> &Handlebars;
+}
+pub trait InternalContentEngine {
+    fn get_internal(&self, route: &Route) -> Option<&ContentRepresentations>;
 }
 
 /// A [`ContentEngine`](trait.ContentEngine.html) that serves files from a
@@ -393,12 +394,18 @@ where
         self.content_registry.get(route)
     }
 
-    fn get_internal(&self, route: &Route) -> Option<&ContentRepresentations> {
-        self.content_registry.get_internal(route)
-    }
-
     fn handlebars_registry(&self) -> &Handlebars {
         &self.handlebars_registry
+    }
+}
+
+impl<'engine, ServerInfo> InternalContentEngine
+    for FilesystemBasedContentEngine<'engine, ServerInfo>
+where
+    ServerInfo: Clone + Serialize,
+{
+    fn get_internal(&self, route: &Route) -> Option<&ContentRepresentations> {
+        self.content_registry.get_internal(route)
     }
 }
 

--- a/src/content/handlebars_helpers/get.rs
+++ b/src/content/handlebars_helpers/get.rs
@@ -1,3 +1,4 @@
+use crate::content::content_engine::InternalContentEngine;
 use crate::content::*;
 use futures::executor;
 use futures::stream::TryStreamExt;
@@ -29,7 +30,7 @@ where
 impl<ServerInfo, Engine> handlebars::HelperDef for GetHelper<ServerInfo, Engine>
 where
     ServerInfo: Clone + Serialize,
-    Engine: ContentEngine<ServerInfo>,
+    Engine: ContentEngine<ServerInfo> + InternalContentEngine,
 {
     fn call<'registry: 'context, 'context>(
         &self,

--- a/src/content/test_lib.rs
+++ b/src/content/test_lib.rs
@@ -43,9 +43,6 @@ impl<'a> ContentEngine<()> for MockContentEngine<'a> {
     fn get(&self, _: &Route) -> Option<&ContentRepresentations> {
         None
     }
-    fn get_internal(&self, _: &Route) -> Option<&ContentRepresentations> {
-        None
-    }
     fn handlebars_registry(&self) -> &Handlebars {
         &self.0
     }


### PR DESCRIPTION
Move `get_internal` to a separate trait so that it's inaccessible from outside of the `content` module.