### PR TITLE
De-genericize types for query parameters.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub fn eval<I: io::Read, O: io::Write>(
 
     let content_item =
         content_engine.new_template(&template, MediaType::APPLICATION_OCTET_STREAM)?;
-    let render_context = content_engine.render_context(None, HashMap::<(), ()>::new());
+    let render_context = content_engine.render_context(None, HashMap::new());
     let media = content_item.render(render_context, &[mime::STAR_STAR])?;
 
     executor::block_on(media.content.try_for_each(|bytes| {
@@ -158,8 +158,7 @@ pub fn get<O: io::Write>(
             .ok_or_else(|| GetCommandError::ContentNotFound {
                 route: route.clone(),
             })?;
-    let render_context =
-        content_engine.render_context(Some(route.clone()), HashMap::<(), ()>::new());
+    let render_context = content_engine.render_context(Some(route.clone()), HashMap::new());
     let media = content_item.render(render_context, &[accept.unwrap_or(mime::STAR_STAR)])?;
 
     executor::block_on(media.content.try_for_each(|bytes| {

--- a/src/content/content_registry.rs
+++ b/src/content/content_registry.rs
@@ -39,14 +39,13 @@ pub enum RegisteredContent {
 
 impl Render for ContentRepresentations {
     type Output = Box<dyn ByteStream>;
-    fn render<'accept, ServerInfo, QueryParameters, Engine, Accept>(
+    fn render<'accept, ServerInfo, Engine, Accept>(
         &self,
-        context: RenderContext<ServerInfo, QueryParameters, Engine>,
+        context: RenderContext<ServerInfo, Engine>,
         acceptable_media_ranges: Accept,
     ) -> Result<Media<Self::Output>, RenderError>
     where
         ServerInfo: Clone + Serialize,
-        QueryParameters: Clone + Serialize,
         Engine: ContentEngine<ServerInfo>,
         Accept: IntoIterator<Item = &'accept MediaRange>,
         Self::Output: ByteStream,
@@ -177,7 +176,8 @@ mod tests {
     fn rendering_with_empty_acceptable_media_ranges_should_fail() {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
-            let render_result = renderable.render(mock_engine.render_context(None, ()), &[]);
+            let render_result =
+                renderable.render(mock_engine.render_context(None, HashMap::new()), &[]);
             assert!(
                 render_result.is_err(),
                 "Rendering item {} with an empty list of acceptable media types did not fail as expected",
@@ -191,7 +191,7 @@ mod tests {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
             let render_result = renderable.render(
-                mock_engine.render_context(None, ()),
+                mock_engine.render_context(None, HashMap::new()),
                 &[::mime::IMAGE_GIF, ::mime::APPLICATION_PDF, ::mime::TEXT_CSS],
             );
             assert!(
@@ -206,8 +206,10 @@ mod tests {
     fn rendering_with_unacceptable_general_media_range_should_fail() {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
-            let render_result =
-                renderable.render(mock_engine.render_context(None, ()), &[::mime::IMAGE_STAR]);
+            let render_result = renderable.render(
+                mock_engine.render_context(None, HashMap::new()),
+                &[::mime::IMAGE_STAR],
+            );
             assert!(
                 render_result.is_err(),
                 "Rendering item {} with unacceptable media types did not fail as expected",
@@ -221,7 +223,7 @@ mod tests {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
             let render_result = renderable.render(
-                mock_engine.render_context(None, ()),
+                mock_engine.render_context(None, HashMap::new()),
                 &[::mime::IMAGE_GIF, ::mime::TEXT_PLAIN, ::mime::TEXT_CSS],
             );
             assert!(
@@ -243,8 +245,10 @@ mod tests {
     fn rendering_with_acceptable_range_star_star_should_succeed() {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
-            let render_result =
-                renderable.render(mock_engine.render_context(None, ()), &[::mime::STAR_STAR]);
+            let render_result = renderable.render(
+                mock_engine.render_context(None, HashMap::new()),
+                &[::mime::STAR_STAR],
+            );
             assert!(
                 render_result.is_ok(),
                 "Rendering item {} with acceptable media type did not succeed as expected: {}",
@@ -258,8 +262,10 @@ mod tests {
     fn rendering_with_acceptable_range_text_star_should_succeed() {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
-            let render_result =
-                renderable.render(mock_engine.render_context(None, ()), &[::mime::TEXT_STAR]);
+            let render_result = renderable.render(
+                mock_engine.render_context(None, HashMap::new()),
+                &[::mime::TEXT_STAR],
+            );
             assert!(
                 render_result.is_ok(),
                 "Rendering item {} with acceptable media type did not succeed as expected: {}",
@@ -281,8 +287,10 @@ mod tests {
     fn can_render_same_content_with_different_representations() {
         let (mock_engine, renderables) = fixtures();
         for (index, renderable) in renderables.iter().enumerate() {
-            let text_plain_result =
-                renderable.render(mock_engine.render_context(None, ()), &[::mime::TEXT_PLAIN]);
+            let text_plain_result = renderable.render(
+                mock_engine.render_context(None, HashMap::new()),
+                &[::mime::TEXT_PLAIN],
+            );
             assert!(
                 text_plain_result.is_ok(),
                 "Rendering item {} with acceptable media type did not succeed as expected: {}",
@@ -295,8 +303,10 @@ mod tests {
                 index,
             );
 
-            let text_html_result =
-                renderable.render(mock_engine.render_context(None, ()), &[::mime::TEXT_HTML]);
+            let text_html_result = renderable.render(
+                mock_engine.render_context(None, HashMap::new()),
+                &[::mime::TEXT_HTML],
+            );
             assert!(
                 text_html_result.is_ok(),
                 "Rendering item {} with acceptable media type did not succeed as expected: {}",

--- a/src/content/test_lib.rs
+++ b/src/content/test_lib.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use std::collections::HashMap;
+
 use super::content_index::ContentIndexEntries;
 use super::*;
 use bytes::{Bytes, BytesMut};
@@ -21,11 +23,11 @@ impl<'a> MockContentEngine<'a> {
     }
 }
 impl<'a> ContentEngine<()> for MockContentEngine<'a> {
-    fn render_context<QueryParameters: Clone + Serialize>(
+    fn render_context(
         &self,
         route: Option<Route>,
-        query_parameters: QueryParameters,
-    ) -> RenderContext<(), QueryParameters, Self> {
+        query_parameters: HashMap<String, String>,
+    ) -> RenderContext<(), Self> {
         RenderContext {
             content_engine: self,
             data: RenderData {


### PR DESCRIPTION
Use a concrete `HashMap<String, String>` instead. This simplifies a bunch of function signatures.