### PR TITLE
Enable usage of query parameters with `get` and `eval` commands.

### DIFF
--- a/samples/render-context/query-string.txt.hbs
+++ b/samples/render-context/query-string.txt.hbs
@@ -1,0 +1,1 @@
+{{#each request.query-parameters}}{{#unless @first}}&{{/unless}}{{@key}}={{this}}{{/each}}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,13 @@ enum OperatorSubcommand {
         /// handlebars template.
         #[structopt(long, parse(from_os_str), value_name = "path")]
         content_directory: PathBuf,
+
+        /// Optional query parameters.
+        ///
+        /// This uses the same format as HTTP requests (without a leading "?").
+        /// For example: --query="a=1&b=2".
+        #[structopt(long, value_name = "query-string")]
+        query: Option<QueryString>,
     },
 
     /// Renders content from a content directory.
@@ -150,10 +157,16 @@ fn handle_subcommand<I: io::Read, O: io::Write>(
     output: &mut O,
 ) -> Result<(), anyhow::Error> {
     match subcommand {
-        OperatorSubcommand::Eval { content_directory } => {
-            cli::eval(get_content_directory(content_directory)?, input, output)
-                .map_err(anyhow::Error::from)
-        }
+        OperatorSubcommand::Eval {
+            content_directory,
+            query,
+        } => cli::eval(
+            get_content_directory(content_directory)?,
+            query,
+            input,
+            output,
+        )
+        .map_err(anyhow::Error::from),
 
         OperatorSubcommand::Get {
             content_directory,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use operator::content::{ContentDirectory, MediaRange, Route};
+use operator::http::QueryString;
 use operator::*;
 use std::fs;
 use std::io;
@@ -44,7 +45,7 @@ enum OperatorSubcommand {
         "EXAMPLE:\n",
         "    mkdir -p content\n",
         "    echo 'hello world' > content/hello.txt\n",
-        "    operator get --content-directory=./content --route=/hello --accept=text/*"
+        "    operator get --content-directory=./content --route=/hello"
     ), display_order = 1)]
     Get {
         /// Path to a directory containing content files.
@@ -59,6 +60,13 @@ enum OperatorSubcommand {
         /// content directory. They must begin with a slash.
         #[structopt(long, value_name = "route")]
         route: Route,
+
+        /// Optional query parameters.
+        ///
+        /// This uses the same format as HTTP requests (without a leading "?").
+        /// For example: --query="a=1&b=2".
+        #[structopt(long, value_name = "query-string")]
+        query: Option<QueryString>,
 
         /// Declares what types of media are acceptable as output.
         ///
@@ -150,10 +158,12 @@ fn handle_subcommand<I: io::Read, O: io::Write>(
         OperatorSubcommand::Get {
             content_directory,
             route,
+            query,
             accept,
         } => cli::get(
             get_content_directory(content_directory)?,
             &route,
+            query,
             accept,
             output,
         )

--- a/tests/snapshots/integration_tests__render-context.snap
+++ b/tests/snapshots/integration_tests__render-context.snap
@@ -5,9 +5,10 @@ input_file: samples/render-context
 
 ---
 a.html: "a\n"
+query-string.txt.hbs: ""
 request-route-wrapper.txt.hbs: "route from this file: /request-route-wrapper\nroute from file included via partial: /request-route-wrapper\nroute from file included via get helper: /request-route-wrapper"
 request-route.txt.hbs: /request-route
-routes.txt.hbs: "a: /a\nrequest-route: /request-route\nrequest-route-wrapper: /request-route-wrapper\nroutes: /routes\nserver-info: /server-info\nwith-empty-context: /with-empty-context\n"
+routes.txt.hbs: "a: /a\nquery-string: /query-string\nrequest-route: /request-route\nrequest-route-wrapper: /request-route-wrapper\nroutes: /routes\nserver-info: /server-info\nwith-empty-context: /with-empty-context\n"
 server-info.txt.hbs: "version: 0.3.0\noperator-path: $PROJECT_DIRECTORY/target/$PROFILE/operator\nsocket-address: $SOCKET_ADDRESS\n"
 with-empty-context.html.hbs: "this with normal context: [object]\nthis with funky context: true\ncalling get for static content with funky context: a\n\n"
 


### PR DESCRIPTION
Both commands now have a `--query` option.