### PR TITLE
The `test-env-log` crate has been renamed `test-log`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
  "stderrlog",
  "structopt",
  "tempfile",
- "test-env-log",
+ "test-log",
  "thiserror",
  "walkdir",
 ]
@@ -2131,10 +2131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-env-log"
+name = "test-log"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877189d680101869f65ef94168105d6c188b3a143c13a2d42cf8a09c4c704f8a"
+checksum = "eb78caec569a40f42c078c798c0e35b922d9054ec28e166f0d6ac447563d91a4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lazy_static = "1.4.0"
 maplit = "1.0.2"
 regex = "1.5.4"
 tempfile = "3.2.0"
-test-env-log = "0.2.8"
+test-log = "0.2.8"
 
 [[bench]]
 name = "load_test"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -228,7 +228,7 @@ mod tests {
     use super::*;
     use crate::test_lib::*;
     use std::str;
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn valid_templates_can_be_evaluated() {

--- a/src/content/content_directory.rs
+++ b/src/content/content_directory.rs
@@ -257,7 +257,7 @@ mod tests {
     use super::*;
     use crate::test_lib::*;
     use std::fs;
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn directory_can_be_created_from_valid_root() {

--- a/src/content/content_engine.rs
+++ b/src/content/content_engine.rs
@@ -428,7 +428,7 @@ mod tests {
     use crate::test_lib::*;
     use ::mime;
     use maplit::hashmap;
-    use test_env_log::test;
+    use test_log::test;
 
     type TestContentEngine<'a> = FilesystemBasedContentEngine<'a, ()>;
 

--- a/src/content/content_index.rs
+++ b/src/content/content_index.rs
@@ -125,7 +125,7 @@ mod tests {
     use super::*;
     use crate::test_lib::*;
     use serde_json::json;
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn index_has_the_correct_structure() {

--- a/src/content/content_item.rs
+++ b/src/content/content_item.rs
@@ -252,7 +252,7 @@ mod tests {
     use std::io::Write;
     use std::str;
     use tempfile::tempfile;
-    use test_env_log::test;
+    use test_log::test;
 
     fn test_render_data() -> RenderData<ServerInfo> {
         RenderData {

--- a/src/content/content_registry.rs
+++ b/src/content/content_registry.rs
@@ -121,7 +121,7 @@ mod tests {
     use crate::test_lib::*;
     use maplit::hashmap;
     use tempfile::tempfile;
-    use test_env_log::test;
+    use test_log::test;
 
     /// All of these will render to an empty string with media type text/plain
     /// or text/html.

--- a/src/content/route.rs
+++ b/src/content/route.rs
@@ -48,7 +48,7 @@ impl fmt::Display for Route {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use test_env_log::test;
+    use test_log::test;
 
     #[test]
     fn valid_routes_succeed() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -429,7 +429,7 @@ mod tests {
     use actix_web::test::TestRequest;
     use bytes::{Bytes, BytesMut};
     use std::path::Path;
-    use test_env_log::test;
+    use test_log::test;
 
     type TestContentEngine<'a> = FilesystemBasedContentEngine<'a, ServerInfo>;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,7 +11,7 @@ use std::env;
 use std::io::Write;
 use std::process::Stdio;
 use std::str;
-use test_env_log::test;
+use test_log::test;
 
 #[actix_rt::test]
 async fn samples_match_snapshots() {


### PR DESCRIPTION
See <https://github.com/d-e-s-o/test-log/blob/HEAD/CHANGELOG.md#028>.