### PR TITLE
Wait longer for the server to start in integration tests/benchmarks.

### DIFF
--- a/benches/load_test.rs
+++ b/benches/load_test.rs
@@ -148,7 +148,9 @@ impl RunningServer {
         let mut process = command.spawn().expect("Failed to spawn process");
 
         // Give the server a chance to start up.
-        thread::sleep(time::Duration::from_millis(500));
+        // TODO: It would be better to poll by retrying a few times if the
+        // connection is refused.
+        thread::sleep(time::Duration::from_secs(1));
 
         // The server may have failed to start if the content directory was invalid.
         if let Ok(Some(_)) = process.try_wait() {

--- a/tests/lib/mod.rs
+++ b/tests/lib/mod.rs
@@ -72,7 +72,7 @@ impl RunningServer {
         // Give the server a chance to start up.
         // TODO: It would be better to poll by retrying a few times if the
         // connection is refused.
-        thread::sleep(time::Duration::from_millis(500));
+        thread::sleep(time::Duration::from_secs(1));
 
         // The server may have failed to start if the content directory was
         // invalid.


### PR DESCRIPTION
I should really do this properly with a retry/backoff loop or something instead of guessing how long it will take, but that's a project for another day.