### PR TITLE
Stop accepting non-`GET` request methods.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -135,9 +135,11 @@ where
                 return error_response(
                     http::StatusCode::BAD_REQUEST,
                     &*content_engine,
-                    None,
-                    HashMap::new(),
-                    HashMap::new(),
+                    RequestData {
+                        route: None,
+                        query_parameters: HashMap::new(),
+                        request_headers: HashMap::new(),
+                    },
                     &app_data.error_handler_route,
                     vec![&mime::TEXT_PLAIN],
                     HeaderMap::new(),
@@ -173,9 +175,11 @@ where
             return error_response(
                 http::StatusCode::BAD_REQUEST,
                 &*content_engine,
-                Some(route),
-                HashMap::new(),
-                HashMap::new(),
+                RequestData {
+                    route: Some(route),
+                    query_parameters: HashMap::new(),
+                    request_headers: HashMap::new(),
+                },
                 &app_data.error_handler_route,
                 vec![&mime::TEXT_PLAIN],
                 HeaderMap::new(),
@@ -195,9 +199,11 @@ where
             return error_response(
                 http::StatusCode::BAD_REQUEST,
                 &*content_engine,
-                Some(route),
-                query_parameters,
-                HashMap::new(),
+                RequestData {
+                    route: Some(route),
+                    query_parameters,
+                    request_headers: HashMap::new(),
+                },
                 &app_data.error_handler_route,
                 vec![&mime::TEXT_PLAIN],
                 HeaderMap::new(),
@@ -223,9 +229,11 @@ where
                 return error_response(
                     http::StatusCode::BAD_REQUEST,
                     &*content_engine,
-                    Some(route),
-                    query_parameters,
-                    request_headers,
+                    RequestData {
+                        route: Some(route),
+                        query_parameters,
+                        request_headers,
+                    },
                     &app_data.error_handler_route,
                     vec![&mime::TEXT_PLAIN],
                     HeaderMap::new(),
@@ -297,9 +305,11 @@ where
             error_response(
                 http::StatusCode::NOT_ACCEPTABLE,
                 &*content_engine,
-                Some(route),
-                query_parameters,
-                request_headers,
+                RequestData {
+                    route: Some(route),
+                    query_parameters,
+                    request_headers,
+                },
                 &app_data.error_handler_route,
                 acceptable_media_ranges,
                 HeaderMap::new(),
@@ -315,9 +325,11 @@ where
             error_response(
                 http::StatusCode::INTERNAL_SERVER_ERROR,
                 &*content_engine,
-                Some(route),
-                query_parameters,
-                request_headers,
+                RequestData {
+                    route: Some(route),
+                    query_parameters,
+                    request_headers,
+                },
                 &app_data.error_handler_route,
                 acceptable_media_ranges,
                 HeaderMap::new(),
@@ -332,9 +344,11 @@ where
             error_response(
                 http::StatusCode::NOT_FOUND,
                 &*content_engine,
-                Some(route),
-                query_parameters,
-                request_headers,
+                RequestData {
+                    route: Some(route),
+                    query_parameters,
+                    request_headers,
+                },
                 &app_data.error_handler_route,
                 acceptable_media_ranges,
                 HeaderMap::new(),
@@ -368,9 +382,11 @@ where
     error_response(
         http::StatusCode::METHOD_NOT_ALLOWED,
         &*content_engine,
-        None,
-        HashMap::new(),
-        HashMap::new(),
+        RequestData {
+            route: None,
+            query_parameters: HashMap::new(),
+            request_headers: HashMap::new(),
+        },
         &app_data.error_handler_route,
         vec![&mime::TEXT_PLAIN],
         response_headers,
@@ -403,9 +419,7 @@ fn log_request(request: &HttpRequest) {
 fn error_response<Engine>(
     status_code: http::StatusCode,
     content_engine: &Engine,
-    request_route: Option<Route>,
-    query_parameters: HashMap<String, String>,
-    request_headers: HashMap<String, String>,
+    request_data: RequestData,
     error_handler_route: &Option<Route>,
     acceptable_media_ranges: Vec<&MediaRange>,
     response_headers: HeaderMap,
@@ -435,7 +449,11 @@ where
         .and_then(|route| {
             content_engine.get(route).and_then(|content| {
                 let error_context = content_engine
-                    .render_context(request_route, query_parameters, request_headers)
+                    .render_context(
+                        request_data.route,
+                        request_data.query_parameters,
+                        request_data.request_headers,
+                    )
                     .into_error_context(status_code.as_u16());
                 match content.render(error_context, acceptable_media_ranges) {
                     Ok(rendered_content) => Some(rendered_content),

--- a/src/http.rs
+++ b/src/http.rs
@@ -67,7 +67,7 @@ where
                     index_route: index_route.clone(),
                     error_handler_route: error_handler_route.clone(),
                 })
-                .default_service(web::get().to(get::<Engine>))
+                .route("/{path:.*}", web::get().to(get::<Engine>))
         })
         .keep_alive(None)
         .bind(socket_address)?

--- a/src/http.rs
+++ b/src/http.rs
@@ -98,32 +98,13 @@ async fn get<Engine>(request: HttpRequest) -> HttpResponse
 where
     Engine: 'static + ContentEngine<ServerInfo> + Send + Sync,
 {
+    log_request(&request);
+
     let app_data = request
         .app_data::<AppData<Engine>>()
         .expect("App data was not of the expected type!");
 
     let path = request.uri().path();
-
-    log::info!(
-        // e.g. "Handling request GET /styles.css HTTP/1.1 with Accept: text/css,*/*;q=0.1"
-        "Handling request {} {} {}{}",
-        request.method(),
-        request.uri(),
-        match request.version() {
-            http::Version::HTTP_09 => "HTTP/0.9",
-            http::Version::HTTP_10 => "HTTP/1.0",
-            http::Version::HTTP_11 => "HTTP/1.1",
-            http::Version::HTTP_2 => "HTTP/2.0",
-            http::Version::HTTP_3 => "HTTP/3.0",
-            _ => "HTTP",
-        },
-        request
-            .headers()
-            .get(header::ACCEPT)
-            .and_then(|value| value.to_str().ok())
-            .map(|value| format!(" with Accept: {}", value))
-            .unwrap_or_default()
-    );
 
     let content_engine = app_data
         .shared_content_engine
@@ -351,6 +332,29 @@ where
             )
         }
     }
+}
+
+fn log_request(request: &HttpRequest) {
+    log::info!(
+        // e.g. "Handling request GET /styles.css HTTP/1.1 with Accept: text/css,*/*;q=0.1"
+        "Handling request {} {} {}{}",
+        request.method(),
+        request.uri(),
+        match request.version() {
+            http::Version::HTTP_09 => "HTTP/0.9",
+            http::Version::HTTP_10 => "HTTP/1.0",
+            http::Version::HTTP_11 => "HTTP/1.1",
+            http::Version::HTTP_2 => "HTTP/2.0",
+            http::Version::HTTP_3 => "HTTP/3.0",
+            _ => "HTTP",
+        },
+        request
+            .headers()
+            .get(header::ACCEPT)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| format!(" with Accept: {}", value))
+            .unwrap_or_default()
+    );
 }
 
 fn error_response<Engine>(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -196,7 +196,15 @@ async fn unsupported_request_methods_are_errors() {
         );
 
         let response = request.send().await.expect("Unable to send HTTP request");
+        let response_allow = response
+            .headers()
+            .get("Allow")
+            .expect("Response was missing Allow header");
 
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+        assert_eq!(
+            response_allow, "GET",
+            "Response did not have an Allow header indicating GET is the only supported method",
+        );
     }
 }


### PR DESCRIPTION
Side note: it was surprising that `app.default_service(web::get().to(handler))` means that `handler` will be called for non-`GET` requests. I filed https://github.com/actix/actix-web/issues/2598 about this.