### PR TITLE
Improve trigger condition for CI workflow.

### DIFF
--- a/.github/workflows/validate-commit.yml
+++ b/.github/workflows/validate-commit.yml
@@ -1,6 +1,10 @@
 name: validate commit
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
CI didn't trigger for <https://github.com/mkantor/operator/pull/100> because the commit didn't come from a push to this repository. I originally did have `pull_request` as a triggering event, but removed it way back in daf8783 because it was kicking off duplicate jobs. I should have instead configured it like this so that only direct pushes to the mainline branch trigger CI (and all pull requests do).