### PR TITLE
Explicitly require the "yaml" feature of insta.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ walkdir = "2.3.2"
 [dev-dependencies]
 criterion = "0.3.6"
 env_logger = "0.9.0"
-insta = "1.18.2"
+insta = { version = "1.18.2", features = ["yaml"] }
 lazy_static = "1.4.0"
 maplit = "1.0.2"
 regex = "1.6.0"


### PR DESCRIPTION
Silences a deprecation warning.