### PR TITLE
Explicitly install support for target of release builds.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
           ~/.cargo/git
           target/release
         key: release-${{ runner.os }}-${{ github.job }}-${{ secrets.CI_CACHE_VERSION }}
+    - run: rustup target add ${{ matrix.target }}
     - run: cargo build --release --target ${{ matrix.target }}
     - name: package binary
       shell: bash


### PR DESCRIPTION
[The `x86_64-apple-darwin` build of the 0.6.2 release failed](https://github.com/mkantor/operator/actions/runs/9909547965) because of a change on GitHub Actions. This change should fix things.