### PR TITLE
Make releases more atomic.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,10 @@ jobs:
 
   publish-crate:
     needs:
+      # While there's no direct dependency between `publish-crate` and
+      # `publish-binary`, if something goes wrong during the binary builds then
+      # the crate should not be published.
+      - publish-binary
       - verify-version
       - test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Wait to publish the crate until the release builds successfully complete.

The 0.6.2 release process had issues (see [1](https://github.com/mkantor/operator/actions/runs/9909547965/job/27378111068), [2](https://github.com/mkantor/operator/pull/114), [3](https://github.com/mkantor/operator/actions/runs/9910582620/job/27381357606)). This is an attempt to make things fail more gracefully the next time something like that happens.