### PR TITLE
Switch to statically-linked musl for Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             artifact_prefix: linux-x86-64
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2


### PR DESCRIPTION
This is to avoid having to think about dynamically-linked glibc compatibility.