### PR TITLE
Update a release dependency.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           shasum -a 256 ${{ github.event.repository.name }}-${{ matrix.artifact_prefix }}.tar.gz \
             > ${{ github.event.repository.name }}-${{ matrix.artifact_prefix }}.sha256
       - name: publish release to github
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             target/${{ matrix.target }}/release/${{ github.event.repository.name }}-${{ matrix.artifact_prefix }}.tar.gz


### PR DESCRIPTION
Bump to `softprops/action-gh-release@v2`.

This wasn't included in #123 because it needs to be validated separately.